### PR TITLE
Remove Deprecation errors

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor, {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -51,299 +51,296 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
 //Comments
-.comment {
+.syntax--comment {
   color: @color1Comment;
   font-style: italic;
 }
 
-.keyword {
+.syntax--keyword {
   color: @color1Keywords;
 
-  &.control {
+  &.syntax--control {
     color: @color1Keywords;
   }
 
-  &.operator {
+  &.syntax--operator {
     color:@color1Keywords;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @color1Keywords;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @color1Other;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @color1Variable;
 }
 
-.constant {
+.syntax--constant {
   color: @color1Constant;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @cyan;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @color1Text;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @cyan;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @color1Constant;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @color1Variable;
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: darken(@dark-gray, 10%);
   }
 
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @syntax-text-color;
   }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: @color1String;
 }
 
-.string {
+.syntax--string {
   color: @color1String;
 
 
-  &.regexp {
+  &.syntax--regexp {
     color: @cyan;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @gray;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @dark-gray;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @color1Comment;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--parameters,
+    &.syntax--array {
       color: @color1String;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @blue;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @color1Other;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @purple;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: darken(@color1Variable, 10%);
   }
 
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color:  @color1Variable;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @color1String;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @color1Constant;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @color1Other;
   }
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @color1Other;
     text-decoration: underline;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @green;
   }
-  &.name.class, &.name.type.class {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @color1Other;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @blue;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @color1Variable;
   }
-  &.gfm{
+  &.syntax--gfm{
     color: @color1String
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @color1Atribute;
 
-    &.id {
+    &.syntax--id {
       color: @color1Atribute;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @color1Atribute;
   }
 
-  &.link {
+  &.syntax--link {
     color: @color1String;
   }
 
-  &.require {
+  &.syntax--require {
     color: @blue;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @purple;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @gray;
     color: @syntax-text-color;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @color1Other;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @purple;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @color1Other;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @purple;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @blue;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @color1Other;
   }
 
-  &.list {
+  &.syntax--list {
     color: @color1Other;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @color1Other;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @green;
   }
-  &.underline.link.gfm {
+  &.syntax--underline.syntax--link.syntax--gfm {
       color: @color1String;
   }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
   -webkit-font-smoothing: auto;
-  &.heading {
+  &.syntax--heading {
     color: @color1Other;
   }
 }
 
-atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
+atom-text-editor[mini] .scroll-view{
   padding-left: 1px;
 }
 
 
 //Json
-.meta .meta .meta .meta .meta .meta.structure.dictionary.value .string {
+.syntax--meta .syntax--meta .syntax--meta .syntax--meta .syntax--meta .syntax--meta.syntax--structure.syntax--dictionary.syntax--value .syntax--string {
     color: @color1String;
 }
-.meta.structure.dictionary.value.json .string.quoted.double.json {
+.syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--string.syntax--quoted.syntax--double.syntax--json {
     color: @color1Variable;
 }
 
-.meta.structure.dictionary.json .string.quoted.double.json {
+.syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--string.syntax--quoted.syntax--double.syntax--json {
   color: @color1Atribute;
 }
 
-.meta .meta .meta .meta.structure.dictionary.value .string {
+.syntax--meta .syntax--meta .syntax--meta .syntax--meta.syntax--structure.syntax--dictionary.syntax--value .syntax--string {
   color: @purple;
 }
 
 
-.meta .meta.structure.dictionary.value .string {
+.syntax--meta .syntax--meta.syntax--structure.syntax--dictionary.syntax--value .syntax--string {
   color: @color1Variable;
 }
 
 //PHP
-.punctuation.definition{
-  &.variable.php{
+.syntax--punctuation.syntax--definition{
+  &.syntax--variable.syntax--php{
     color: @color1Variable;
   }
-  &.parameters.php{
+  &.syntax--parameters.syntax--php{
     color:@color1Text;
   }
 }
-.support.function.php{
+.syntax--support.syntax--function.syntax--php{
   color:@color1Atribute;
 
 }


### PR DESCRIPTION
Followed Atom guidelines of removing :host pseudo-selector and prefixing syntax-- to all syntax selectors. Successfully gets rid of deprecation errors and fixes  #1 